### PR TITLE
Don't normalize fields typed with `Any`

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -13,6 +13,7 @@ Fixed
 ^^^^^
 - When using ``model_dump``, ignore invalid ``attributes`` and ``excluded_attributes``
   as suggested by RFC7644.
+- Don't normalize attributes typed with :data:`Any`. :issue:`20`
 
 [0.3.7] - 2025-07-17
 --------------------


### PR DESCRIPTION
So agnostic fields like PatchOp.operation.value are correctly cased
Fixes #70 