### PR TITLE
Allow empty array for Resources when totalResults is non-zero

### DIFF
--- a/scim2_models/messages/list_response.py
+++ b/scim2_models/messages/list_response.py
@@ -60,7 +60,7 @@ class ListResponse(Message, Generic[AnyResource], metaclass=_GenericMessageMetac
                 "Field 'total_results' is required but value is missing or null",
             )
 
-        if obj.total_results > 0 and not obj.resources:
+        if obj.total_results > 0 and obj.resources is None:
             raise PydanticCustomError(
                 "no_resource_error",
                 "Field 'resources' is missing or null but 'total_results' is non-zero.",

--- a/tests/test_list_response.py
+++ b/tests/test_list_response.py
@@ -186,10 +186,7 @@ def test_zero_results():
     ListResponse[User].model_validate(payload, scim_ctx=Context.RESOURCE_QUERY_RESPONSE)
 
     payload = {"totalResults": 1, "Resources": []}
-    with pytest.raises(ValidationError):
-        ListResponse[User].model_validate(
-            payload, scim_ctx=Context.RESOURCE_QUERY_RESPONSE
-        )
+    ListResponse[User].model_validate(payload, scim_ctx=Context.RESOURCE_QUERY_RESPONSE)
 
     payload = {"totalResults": 1}
     with pytest.raises(ValidationError):


### PR DESCRIPTION
As said in the rfc and in the docstring, resources must be set if totalResults is non-zero. However, scim2-models does not accept an empty list because in Python it is considered as falsy value.

This is fixed by checking if resources is None. That's it.