### PR TITLE
Resolve "License in project metadata can be simplified"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "scim2-models"
 version = "0.6.12"
 description = "SCIM2 models serialization and validation with pydantic"
 authors = [{name="Yaal Coop", email="contact@yaal.coop"}]
-license = {file = "LICENSE"}
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 readme = "README.md"
 keywords = ["scim", "scim2", "provisioning", "pydantic", "rfc7643", "rfc7644"]
 classifiers = [
@@ -19,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
-    "License :: OSI Approved :: Apache Software License",
     "Environment :: Web Environment",
     "Programming Language :: Python",
     "Operating System :: OS Independent",


### PR DESCRIPTION
This PR sets the license to a value compliant with the SPDX specification and removes the deprecated license classifier from the project metadata.

Testing done via:

```bash
❯ uv build -q .
❯ unzip -qo dist/scim2_models-0.6.12-py3-none-any.whl
❯ grep License scim2_models-0.6.12.dist-info/METADATA
License-Expression: Apache-2.0
License-File: LICENSE
```

NOTE: The official maintainers of this project should set a year and the copyright holders in the license file of this project.

Closes #152 