### PR TITLE
Fix mutability and required checks resolve the field name

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -66,6 +66,11 @@ Fixed
 - :meth:`~scim2_models.Resource.from_schema` no longer crashes on ``reference`` attributes missing the optional ``referenceTypes``, and reads them as :class:`~scim2_models.URI` references.
 - Looking a model up by schema no longer crashes when the model list mixes resources with messages such as :class:`~scim2_models.ListResponse`.
 - Check recursively extensions' replace constraints.
+- The ``readOnly``, ``immutable`` and ``required`` constraints of a PATCH operation are checked
+  against the attribute its path resolves to, instead of against a literal field name match.
+  They used to be skipped whenever the two differed, so ``userName`` could be removed and a
+  path spelled ``GROUPS`` could write to a ``readOnly`` attribute, :rfc:`7643` §2.1 making
+  attribute names case-insensitive.
 
 Removed
 ^^^^^^^

--- a/scim2_models/messages/patch_op.py
+++ b/scim2_models/messages/patch_op.py
@@ -22,10 +22,25 @@ from ..exceptions import NoTargetException
 from ..path import URN
 from ..path import Path
 from ..resources.resource import Resource
+from ..utils import _find_field_name
 from .message import Message
 from .message import _get_resource_class
 
 ResourceT = TypeVar("ResourceT", bound=Resource[Any])
+
+
+def _resolved_field(
+    resource_class: type[Resource[Any]], attr_name: str | None
+) -> str | None:
+    """Return the Python field a SCIM attribute name designates.
+
+    Attribute names are case-insensitive per :rfc:`RFC7643 §2.1 <7643#section-2.1>`
+    and differ from the field names of the model, so the constraint checks
+    resolve the name instead of matching it against ``model_fields``.
+    """
+    if attr_name is None:
+        return None
+    return _find_field_name(resource_class, attr_name)
 
 
 class PatchOperation(ComplexAttribute, Generic[ResourceT]):
@@ -50,7 +65,7 @@ class PatchOperation(ComplexAttribute, Generic[ResourceT]):
     describing the target of the operation."""
 
     def _validate_mutability(
-        self, resource_class: type[Resource[Any]], field_name: str
+        self, resource_class: type[Resource[Any]], field_name: str | None
     ) -> None:
         """Validate mutability constraints at parse-time.
 
@@ -59,10 +74,10 @@ class PatchOperation(ComplexAttribute, Generic[ResourceT]):
         to the resource instance and is enforced at runtime in
         :meth:`PatchOp._check_immutable`.
         """
-        if field_name not in resource_class.model_fields:
+        if (field := _resolved_field(resource_class, field_name)) is None:
             return
 
-        mutability = resource_class.get_field_annotation(field_name, Mutability)
+        mutability = resource_class.get_field_annotation(field, Mutability)
 
         if mutability == Mutability.read_only:
             raise MutabilityException(
@@ -70,7 +85,7 @@ class PatchOperation(ComplexAttribute, Generic[ResourceT]):
             ).as_pydantic_error()
 
     def _validate_required_attribute(
-        self, resource_class: type[Resource[Any]], field_name: str
+        self, resource_class: type[Resource[Any]], field_name: str | None
     ) -> None:
         """Validate required attribute constraints for remove operations."""
         # RFC 7644 Section 3.5.2.3: Only validate for remove operations
@@ -78,10 +93,10 @@ class PatchOperation(ComplexAttribute, Generic[ResourceT]):
             return
 
         # RFC 7644 Section 3.5.2: "Servers should be tolerant of schema extensions"
-        if field_name not in resource_class.model_fields:
+        if (field := _resolved_field(resource_class, field_name)) is None:
             return
 
-        required = resource_class.get_field_annotation(field_name, Required)
+        required = resource_class.get_field_annotation(field, Required)
 
         # RFC 7643 Section 7: "Required attributes SHALL NOT be removed"
         if required == Required.true:
@@ -238,8 +253,8 @@ class PatchOp(Message, Generic[ResourceT]):
                 continue
 
             field_name = operation.path.parts[0] if operation.path.parts else None
-            operation._validate_mutability(resource_class, field_name)  # type: ignore[arg-type]
-            operation._validate_required_attribute(resource_class, field_name)  # type: ignore[arg-type]
+            operation._validate_mutability(resource_class, field_name)
+            operation._validate_required_attribute(resource_class, field_name)
 
         return self
 
@@ -311,14 +326,14 @@ class PatchOp(Message, Generic[ResourceT]):
         resource_class = type(resource)
         assert operation.path is not None
         field_name = operation.path.parts[0] if operation.path.parts else None
-        if field_name is None or field_name not in resource_class.model_fields:
+        if (field := _resolved_field(resource_class, field_name)) is None:
             return
 
-        mutability = resource_class.get_field_annotation(field_name, Mutability)
+        mutability = resource_class.get_field_annotation(field, Mutability)
         if mutability != Mutability.immutable:
             return
 
-        current_value = getattr(resource, field_name, None)
+        current_value = getattr(resource, field, None)
 
         if operation.op == PatchOperation.Op.add and current_value is None:
             return

--- a/tests/test_patch_op_validation.py
+++ b/tests/test_patch_op_validation.py
@@ -121,22 +121,22 @@ def test_validate_patchop_case_insensitivity():
         {
             "schemas": ["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
             "operations": [
-                {"op": "Replace", "path": "userName", "value": "Rivard"},
-                {"op": "ADD", "path": "userName", "value": "Rivard"},
-                {"op": "ReMove", "path": "userName", "value": "Rivard"},
+                {"op": "Replace", "path": "displayName", "value": "Rivard"},
+                {"op": "ADD", "path": "displayName", "value": "Rivard"},
+                {"op": "ReMove", "path": "displayName", "value": "Rivard"},
             ],
         },
     ) == PatchOp[User](
         schemas=["urn:ietf:params:scim:api:messages:2.0:PatchOp"],
         operations=[
             PatchOperation[User](
-                op=PatchOperation.Op.replace_, path="userName", value="Rivard"
+                op=PatchOperation.Op.replace_, path="displayName", value="Rivard"
             ),
             PatchOperation[User](
-                op=PatchOperation.Op.add, path="userName", value="Rivard"
+                op=PatchOperation.Op.add, path="displayName", value="Rivard"
             ),
             PatchOperation[User](
-                op=PatchOperation.Op.remove, path="userName", value="Rivard"
+                op=PatchOperation.Op.remove, path="displayName", value="Rivard"
             ),
         ],
     )
@@ -683,3 +683,72 @@ def test_patch_op_operations_attribute_required_in_patch_context():
         context={"scim": Context.RESOURCE_PATCH_REQUEST},
     )
     assert len(patch_op.operations) == 1
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "groups",
+        "GROUPS",
+        "Groups",
+        "urn:ietf:params:scim:schemas:core:2.0:User:groups",
+    ],
+)
+def test_a_read_only_attribute_is_protected_whatever_its_spelling(path):
+    """Attribute names are case-insensitive per :rfc:`RFC7643 §2.1 <7643#section-2.1>`.
+
+    ``groups`` is readOnly, so every spelling designating it must be refused.
+    """
+    with pytest.raises(ValidationError, match="mutability"):
+        PatchOp[User](
+            operations=[
+                PatchOperation[User](
+                    op=PatchOperation.Op.replace_,
+                    path=path,
+                    value=[{"value": "group-id"}],
+                )
+            ]
+        )
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["userName", "USERNAME", "urn:ietf:params:scim:schemas:core:2.0:User:userName"],
+)
+def test_a_required_attribute_cannot_be_removed_whatever_its_spelling(path):
+    """``userName`` is required, and its SCIM name differs from its field name."""
+    with pytest.raises(ValidationError, match="required attribute cannot be removed"):
+        PatchOp[User](
+            operations=[PatchOperation[User](op=PatchOperation.Op.remove, path=path)]
+        )
+
+
+def test_an_immutable_attribute_is_protected_whatever_its_spelling():
+    """The runtime check reads the current value, so it resolves the name too."""
+    resource = ImmutableFieldResource(locked="original")
+    patch = PatchOp[ImmutableFieldResource](
+        operations=[
+            PatchOperation[ImmutableFieldResource](
+                op=PatchOperation.Op.replace_, path="LOCKED", value="hijacked"
+            )
+        ]
+    )
+
+    with pytest.raises(MutabilityException):
+        patch.patch(resource)
+    assert resource.locked == "original"
+
+
+def test_an_operation_on_the_resource_root_has_no_attribute_to_check():
+    """An empty path designates the resource itself, so no constraint applies."""
+    resource = User(user_name="bjensen")
+    patch = PatchOp[User](
+        operations=[
+            PatchOperation[User](
+                op=PatchOperation.Op.add, path="", value={"displayName": "Barbara"}
+            )
+        ]
+    )
+
+    assert patch.patch(resource)
+    assert resource.display_name == "Barbara"


### PR DESCRIPTION
The readOnly, immutable and required constraints of a PATCH operation were looked up with `parts[0]`, the attribute name as the client spelled it, against `model_fields`, whose keys are Python field names. The guard was skipped whenever the two differed, so removing `userName` succeeded on a required attribute, and RFC7643 §2.1 making attribute names case-insensitive, a path spelled `GROUPS` wrote to a readOnly one.

The three checks now resolve the name through `_find_field_name` and only give up when nothing matches. Error messages keep the client's spelling, which is what a SCIM peer understands.